### PR TITLE
Update preference locations to conform to modern COC usage

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,7 +17,7 @@ Changing your `coc-settings.json` file will change the behavior of `coc-bibtex` 
 
 ### Setting BibTeX File Location
 
-Set `list.source.bibtex.files` to an array containing your `.bib` files. For instance, in `coc-settings.json`:
+Set `coc.preferences.bibtex.files` to an array containing your `.bib` files. For instance, in `coc-settings.json`:
 
 ~~~json
 {
@@ -38,7 +38,7 @@ Set `list.source.bibtex.files` to an array containing your `.bib` files. For ins
 Or in vimrc:
 
 ~~~vim
-call coc#config('list.source.bibtex', {
+call coc#config('coc.preferences.bibtex', {
   \  'files': [
   \    '~/my-library.bib'
   \  ]
@@ -55,12 +55,12 @@ By default, the following filetypes are supported for completion:
 * pandoc
 * markdown
 
-To change this behavior, determine the `filetype` (in Vim) you wish to add. This can be done by running `:set filetype?` with the kind of file you wish to support. Then, edit `coc.source.bibtex.filetypes` to include the `filetype` you wish to support (you will also have to include the default types, too).
+To change this behavior, determine the `filetype` (in Vim) you wish to add. This can be done by running `:set filetype?` with the kind of file you wish to support. Then, edit `coc.preferences.bibtex.filetypes` to include the `filetype` you wish to support (you will also have to include the default types, too).
 
 If, for instance, you wanted to add support for `.textile` files, you would need to include the following in your `coc-settings.json` file:
 
 ~~~json
-coc.source.bibtex.filetypes: [
+coc.preferences.bibtex.filetypes: [
 	"tex",
 	"plaintex",
 	"latex",
@@ -83,12 +83,12 @@ To trigger completion with a citation command in LaTeX, instead of the pandoc-st
 ~~~json
 {
 //...
-  "coc.source.bibtex.triggerPatterns": ["\\\\cite\\{"],
-  "coc.source.bibtex.triggerCharacters": []
+  "coc.preferences.bibtex.triggerPatterns": ["\\\\cite\\{"],
+  "coc.preferences.bibtex.triggerCharacters": []
 }
 ~~~
 
-This will also work for the `\cite{}` command. Changing `coc.source.bibtex.triggerPatterns` to `cite\\{` will work for any of the commands that end in `cite`, not just `\cite`.
+This will also work for the `\cite{}` command. Changing `coc.preferences.bibtex.triggerPatterns` to `cite\\{` will work for any of the commands that end in `cite`, not just `\cite`.
 
 #### List
 
@@ -100,7 +100,7 @@ In `coc-settings.json`:
 {
 //...
 
-"list.source.bibtex": {
+"coc.preferences.bibtex": {
     "citation": {
       "before": "\\cite{",
       "after": "}"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "configuration": {
       "type": "object",
       "properties": {
-        "list.source.bibtex.files": {
+        "coc.preferences.bibtex.files": {
           "type": "array",
           "default": [],
           "description": "List of .bib files to read.",
@@ -41,7 +41,7 @@
             "type": "string"
           }
         },
-        "list.source.bibtex.citation": {
+        "coc.preferences.bibtex.citation": {
           "type": "object",
           "default": {
             "before": "[@",
@@ -66,11 +66,11 @@
           "type": "boolean",
           "default": false
         },
-        "coc.source.bibtex.shortcut": {
+        "coc.preferences.bibtex.shortcut": {
           "type": "string",
           "default": "BIB"
         },
-        "coc.source.bibtex.triggerCharacters": {
+        "coc.preferences.bibtex.triggerCharacters": {
           "type": "array",
           "default": [
             "@"
@@ -79,14 +79,14 @@
             "type": "string"
           }
         },
-        "coc.source.bibtex.triggerPatterns": {
+        "coc.preferences.bibtex.triggerPatterns": {
           "type": "array",
           "default": [],
           "items": {
             "type": "string"
           }
         },
-        "coc.source.bibtex.filetypes": {
+        "coc.preferences.bibtex.filetypes": {
           "type": [
             "array",
             "null"

--- a/src/cacheFullFilePaths.ts
+++ b/src/cacheFullFilePaths.ts
@@ -1,11 +1,11 @@
 import {workspace} from 'coc.nvim'
 const cacheFullFilePaths = async (): Promise<string[]> => {
   const {nvim} = workspace
-  const config = workspace.getConfiguration('list.source.bibtex')
+  const config = workspace.getConfiguration('coc.preferences.bibtex')
   const files = config.get<string[]>('files', [])
   const output = []
   if (files.length === 0) {
-    workspace.showMessage('No .bib files provided; set list.source.bibtex to a list of .bib files')
+    workspace.showMessage('No .bib files provided; set coc.preferences.bibtex to a list of .bib files')
   }
   const globRegexp = new RegExp('\\*', 'g');
   for (const file of files) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   async function updateCache(): Promise<void> {
     const filetype = await nvim.eval('&filetype')
-    const filetypes = config.get('coc.source.bibtex.filetypes', [
+    const filetypes = config.get('coc.preferences.bibtex.filetypes', [
       'tex',
       'plaintex',
       'latex',

--- a/src/list.ts
+++ b/src/list.ts
@@ -49,7 +49,7 @@ export default class FilesList extends BasicList {
   private async cacheFilePaths(): Promise<void> {
     const filetype = await workspace.nvim.eval('&filetype')
     const config = workspace.getConfiguration()
-    const filetypes = config.get('coc.source.bibtex.filetypes', [
+    const filetypes = config.get('coc.preferences.bibtex.filetypes', [
       'tex',
       'plaintex',
       'latex',

--- a/src/makeCitation.ts
+++ b/src/makeCitation.ts
@@ -6,7 +6,7 @@ interface CitationConfiguration {
 }
 
 const makeCitation = (id:string):string => {
-  const config = workspace.getConfiguration('list.source.bibtex')
+  const config = workspace.getConfiguration('coc.preferences.bibtex')
   const {before,after} = config.get<CitationConfiguration>('citation', {before: '[@', after: ']'})
   return `${before}${id}${after}`
 }


### PR DESCRIPTION
breaking change: make changes to preferences requested in #21

This moves all preferences stored in `coc.source` and `list.source` to `coc.preferences`.